### PR TITLE
Update menu.py to handle Nuke Assist

### DIFF
--- a/nuke/menu.py
+++ b/nuke/menu.py
@@ -1,2 +1,6 @@
-m = nuke.menu( 'Nodes' ).findItem( 'Deep' )
-m.addCommand( 'DeepOpenEXRId', lambda: nuke.createNode('DeepOpenEXRId') )
+m = nuke.menu( 'Nodes' ).findItem( 'Deep' ) 
+try:
+    m.addCommand( 'DeepOpenEXRId', lambda: nuke.createNode('DeepOpenEXRId') )
+except AttributeError:
+    # The case with Nuke Assist.
+    pass


### PR DESCRIPTION
Because of some limitations of Nuke Assist, the current `menu.py` raises an AttributeError. This simple patch is intended to fix the problem.